### PR TITLE
Net! Socket & Server classes updated (major changes)

### DIFF
--- a/js/node/Net.hx
+++ b/js/node/Net.hx
@@ -8,7 +8,7 @@ typedef TCPSocketOptions = {
   @:optional var allowHalfOpen: Bool;
 }
 
-typedef UNIXsocketOptions = {
+typedef UNIXSocketOptions = {
   var path: String;
   @:optional var allowHalfOpen: Bool;
 }

--- a/js/node/Net.hx
+++ b/js/node/Net.hx
@@ -1,5 +1,24 @@
 package js.node;
 
+// NetConnectionOpt replaced by TPCSocketOptions
+typedef TCPSocketOptions = {
+  var port: Int;
+  @:optional var host: String;
+  @:optional var localAddress: String;
+  @:optional var allowHalfOpen: Bool;
+}
+
+typedef UNIXsocketOptions = {
+  var path: String;
+  @:optional var allowHalfOpen: Bool;
+}
+ 
+typedef Address = {
+  var port: Int;
+  var family: String;
+  var address: String;
+}
+
 /* NET ............................................. */
   
 /* 
@@ -11,19 +30,17 @@ extends js.node.events.EventEmitter
 implements npm.Package.Require<"net","*"> 
 {
   static function createServer(?options:{allowHalfOpen:Bool},fn:js.node.net.Socket->Void):js.node.net.Server;
-  @:overload(function(cs:String):js.node.net.Socket {})
-  static function createConnection(port:Int,host:String):js.node.net.Socket;
-  @:overload(function(cs:String):js.node.net.Socket {})
-  static function connect(port:Int,host:String):js.node.net.Socket;                    
+
+  @:overload(function(path: String, ?connectListener: Void->Void): js.node.net.Socket {}) // Unix socket
+  @:overload(function(options: Dynamic, ?connectListener: Void->Void): js.node.net.Socket {}) // options is TPCSocket or UNIXSocket
+  static function createConnection(port:Int, ?host:String, ?connectListener: Void->Void):js.node.net.Socket; // TCP Socket
+
+  @:overload(function(path: String, ?connectListener: Void->Void): js.node.net.Socket {}) // Unix socket
+  @:overload(function(options: Dynamic, ?connectListener: Void->Void): js.node.net.Socket {}) // options is TPCSocket or UNIXSocket
+  static function connect(port:Int, ?host:String, ?connectListener: Void->Void):js.node.net.Socket;
+
   static function isIP(input:String):Int; // 4 or 6
   static function isIPv4(input:String):Bool;
   static function isIPv6(input:String):Bool;
-}
-
-
-typedef NetConnectionOpt = {
-    port:Int,
-    ?host:String,
-    ?localAddress:String
 }
 

--- a/js/node/Net.hx
+++ b/js/node/Net.hx
@@ -32,11 +32,13 @@ implements npm.Package.Require<"net","*">
   static function createServer(?options:{allowHalfOpen:Bool},fn:js.node.net.Socket->Void):js.node.net.Server;
 
   @:overload(function(path: String, ?connectListener: Void->Void): js.node.net.Socket {}) // Unix socket
-  @:overload(function(options: Dynamic, ?connectListener: Void->Void): js.node.net.Socket {}) // options is TPCSocket or UNIXSocket
+  @:overload(function(options: TCPSocketOptions, ?connectListener: Void->Void): js.node.net.Socket {})
+  @:overload(function(options: UNIXSocketOptions, ?connectListener: Void->Void): js.node.net.Socket {})
   static function createConnection(port:Int, ?host:String, ?connectListener: Void->Void):js.node.net.Socket; // TCP Socket
 
   @:overload(function(path: String, ?connectListener: Void->Void): js.node.net.Socket {}) // Unix socket
-  @:overload(function(options: Dynamic, ?connectListener: Void->Void): js.node.net.Socket {}) // options is TPCSocket or UNIXSocket
+  @:overload(function(options: TCPSocketOptions, ?connectListener: Void->Void): js.node.net.Socket {})
+  @:overload(function(options: UNIXSocketOptions, ?connectListener: Void->Void): js.node.net.Socket {})
   static function connect(port:Int, ?host:String, ?connectListener: Void->Void):js.node.net.Socket;
 
   static function isIP(input:String):Int; // 4 or 6

--- a/js/node/net/Server.hx
+++ b/js/node/net/Server.hx
@@ -1,7 +1,7 @@
 package js.node.net;
 
 import js.node.Net;
-  
+
 /* 
    Emits:
    connection,close,error,listening
@@ -10,23 +10,23 @@ extern class Server
 extends js.node.events.EventEmitter 
 implements npm.Package.RequireNamespace<"net","*">
 {
-
-  public static inline var EVENT_REQUEST = "request";
   public static inline var EVENT_CONNECTION = "connection";
   public static inline var EVENT_CLOSE = "close";
-  public static inline var EVENT_CHECK_CONTINUE = "checkContinue";
-  public static inline var EVENT_CONNECT = "connect";
-  public static inline var EVENT_UPGRADE = "upgrade";
-  public static inline var EVENT_CLIENT_ERROR = "clientError";
+  public static inline var EVENT_LISTENING = "listening";
+  public static inline var EVENT_ERROR = "error";
 
   var maxConnections:Int;
+
+  // @DEPRECATED
   var connections:Int;
 
-  @:overload(function(path:String,?cb:Void->Void):Void {})
-  @:overload(function(fd:Int,?cb:Void->Void):Void {})                        
-  function listen(port:Int,?host:String,?cb:Void->Void):Void;
-  function close(cb:Void->Void):Void;
-  function address():Void;
-  function pause(msecs:Int):Void;
+  @:overload(function(path:String,?callback:Void->Void):Void {})
+  @:overload(function(fd:Int,?callback:Void->Void):Void {})                        
+  function listen(port:Int,?host:String, ?backlog: Int, ?callback:Void->Void):Void;
+  function close(callback:Void->Void):Void;
+  function address(): js.node.Address;
+  function unref(): Void;
+  function ref(): Void;
+  function getConnections(callback: String->Int->Void): Void;
 
 }

--- a/js/node/net/Socket.hx
+++ b/js/node/net/Socket.hx
@@ -1,6 +1,14 @@
 package js.node.net;
 
 import js.node.Net;
+
+typedef SocketOptions = {
+  @:optional var fd: Int;
+  @:optional var allowHalfOpen: Bool;
+  @:optional var readable: Bool;
+  @:optional var writable: Bool;
+}
+
 /*
   
   Emits:
@@ -12,27 +20,37 @@ extern class Socket
 implements npm.Package.RequireNamespace<"net","*">
 extends js.node.events.EventEmitter 
 {
-  var remoteAddress:String;
-  var remotePort:Int;
-  var bufferSize:Int;
-  var bytesRead:Int;
-  var bytesWritten:Int;
-                          
-  @:overload(function(path:String,?cb:Void->Void):Void {})
-  @:overload(function(options:NetConnectionOpt,connectionListener:Void->Void):Void {})
-  function connect(port:Int,?host:String,?cb:Void->Void):Void;
-  function setEncoding(enc:String):Void;
-  function setSecure():Void;
-  @:overload(function(data:Dynamic,?enc:String,?fileDesc:Int,?cb:Void->Void):Bool {})
-  function write(data:Dynamic,?enc:String,?cb:Void->Void):Bool;
-  function end(?data:Dynamic,?enc:String):Void;
-  function destroy():Void;
-  function pause():Void;
-  function resume():Void;
-  function setTimeout(timeout:Int,?cb:Void->Void):Void;
-  function setNoDelay(?noDelay:Bool):Void;
-  function setKeepAlive(enable:Bool,?delay:Int):Void;
-  function address():{address:String,port:Int}; 
-  function new(?options:Dynamic):Void;
+    public static inline var EVENT_TIMEOUT = "timeout";
+    public static inline var EVENT_CONNECT = "connect";
+    public static inline var EVENT_CLOSE = "close";
+    public static inline var EVENT_ERROR = "error";
+    public static inline var EVENT_DRAIN = "drain";
+    public static inline var EVENT_DATA = "data";
+    public static inline var EVENT_END = "end";
+    
+    var remoteAddress:String;
+    var remotePort:Int;
+    var localAddress: String;
+    var localPort: Int;
+    var bufferSize:Int;
+    var bytesRead:Int;
+    var bytesWritten:Int;
+                            
+    @:overload(function(path:String,?connectListener:Void->Void):Void {})
+    function connect(port:Int,?host:String,?connectListener:Void->Void):Void;
 
+    function setEncoding(?encoding:String):Void;
+    function setSecure():Void;
+    function write(data:Dynamic,?encoding:String,?callback:Void->Void):Bool;
+    function end(?data:Dynamic,?encoding:String):Void;
+    function destroy():Void;
+    function pause():Void;
+    function resume():Void;
+    function setTimeout(timeout:Int,?callback:Void->Void):Void;
+    function setNoDelay(?noDelay:Bool):Void;
+    function setKeepAlive(?enable:Bool,?delay:Int):Void;
+    function address():js.node.Address;
+    function unref(): Void;
+    function ref(): Void;
+    function new(?options:SocketOptions):Void;
 }


### PR DESCRIPTION
Hello,

Sorry, again a PR, but I prefer sending a PR for this changes, because some functions disappears, some appears, new data types. I don't know how were these classes before in node api, so, I don't know if that's functions & overload were wanted (for a weird reason) or if they were just outdated.

Note : "connections" param in js.node.net.Server is deprecated

Regards,
Peekmo