### PR TITLE
Add working express.Static middleware

### DIFF
--- a/js/npm/express/Static.hx
+++ b/js/npm/express/Static.hx
@@ -1,0 +1,15 @@
+package js.npm.express;
+
+typedef StaticOptions = {
+  ?maxAge : Int,
+  ?hidden : Bool,
+  ?redirect : Bool
+}
+
+@:native('static')
+extern class Static 
+implements npm.Package.RequireNamespace<"express","*"> #if !haxe3,#end
+implements js.npm.connect.Middleware
+{
+  public function new( path : String , ?opts : StaticOptions ) : Void;
+}


### PR DESCRIPTION
Hello! I've noticed `js.npm.connect.Static` doesn't work, because it produces JS `require("connect")["static"]` which is undefined. I don't know if it's a difference in versions, so I didn't remove the `js.npm.connect.Static` class, but I did add a `js.npm.express.Static` class with correct namespace. (Producing `require("express")["static"] instead.)

Before, with this code:

``` haxe
import js.npm.connect.Static;
// (...)
app.use(new Static(Node.__dirname + "/public"));
```

Node complains:

```
var middleware = new (Static__6||require("connect").static)(js.Node.__dirnam
                         ^
TypeError: undefined is not a function
```

After changing the initial import to `js.npm.express.Static` it works.
