### PR TITLE
Buffer.toString() has no required arguments

### DIFF
--- a/js/node/Buffer.hx
+++ b/js/node/Buffer.hx
@@ -15,7 +15,7 @@ implements ArrayAccess<Int>
   function copy(targetBuffer:Buffer,targetStart:Int,sourceStart:Int,sourceEnd:Int):Void;
   function slice(start:Int,end:Int):Buffer;
   function write(s:String,?offset:Int,?length:Int,?enc:String):Int;
-  function toString(enc:String,?start:Int,?end:Int):String;
+  function toString(?enc:String,?start:Int,?end:Int):String;
   function fill(value:Float,offset:Int,?end:Int):Void;
   static function isBuffer(o:Dynamic):Bool;
   static function byteLength(s:String,?enc:String):Int;


### PR DESCRIPTION
See http://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end
