### PR TITLE
Explicit overload/override to use app.get('setting')

### DIFF
--- a/js/npm/express/Application.hx
+++ b/js/npm/express/Application.hx
@@ -21,5 +21,8 @@ extends MiddlewareHttp
 	function engine( ext : String , engine : ViewEngine ) : Application;
 	function set( setting : String , value : Dynamic ) : Application;
 
-	
+	@:overload(function<Req:Request,Res:Response>(path : Route , f : Array<TMiddleware<Req,Res>> ) : Application {})
+	@:overload(function<Req:Request,Res:Response>(path : Route , f : TMiddleware<Req,Res> ) : Application {})
+	@:overload(function ( setting : String ): Dynamic { } )
+	override function get( path : Route, f : MiddlewareResponder<Request,Response> ) : Application;
 }

--- a/util/CopyMethods.hx
+++ b/util/CopyMethods.hx
@@ -69,6 +69,16 @@ class CopyMethods {
 								case _ : throw 'assert';
 
 							}
+
+							// Special case for the get method
+							if(method == 'get') {
+								f.meta.push({
+									pos : f.pos,
+									params : [macro function(setting : String) : Dynamic {}],
+									name : ":overload"
+								});								
+							}
+
 							fields.push(f);
 						case _ : throw 'assert';
 					}

--- a/util/CopyMethods.hx
+++ b/util/CopyMethods.hx
@@ -69,16 +69,6 @@ class CopyMethods {
 								case _ : throw 'assert';
 
 							}
-
-							// Special case for the get method
-							if(method == 'get') {
-								f.meta.push({
-									pos : f.pos,
-									params : [macro function(setting : String) : Dynamic {}],
-									name : ":overload"
-								});								
-							}
-
 							fields.push(f);
 						case _ : throw 'assert';
 					}


### PR DESCRIPTION
Would this be good enough to be able to use app.get() for boths settings and routing?