### PR TITLE
Cleaned up mongoose/Model.hx

### DIFF
--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -1,9 +1,7 @@
 package js.npm.mongoose;
 
 import js.support.Callback;
-
-private abstract Either<T1, T2>(Dynamic)
-from T1 from T2 to T1 to T2 {}
+import js.support.Either;
 
 @:native("Model")
 extern class TModel<T>

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -69,8 +69,8 @@ extern class TModels<T,M:TModel<T>> {
 	@:overload( function( conditions : {} , update : {} , ?options : {},  ?callback : Callback<Int> ) : Query<Array<M>> {} )
 	public function update( conditions : {} , update : {} , ?options : {},  ?callback : Callback2<Int, Dynamic> ) : Query<Array<M>>;
 
-	@:overload( function( o : ModelMapReduce , ?callback : Callback<Array<M>> ) : Void {} )
-	public function mapReduce( o : ModelMapReduce , ?callback : Callback2<Array<M>,{}> ) : Void;
+	@:overload( function( o : ModelMapReduce , ?callback : Callback<Array<M>> ) : Promise {} )
+	public function mapReduce( o : ModelMapReduce , ?callback : Callback2<Array<M>,{}> ) : Promise;
 
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , c4 : {} , c5 : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , c4 : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -52,7 +52,7 @@ extern class TModels<T,M:TModel<T>> {
 	public function findOneAndRemove( ?conditions : {} , ?options : {} , ?callback : Callback<Null<M>> ) : Query<M>;
 
 	public function findByIdAndUpdate( ?id : Dynamic , ?update : {} , ?options : {} , ?callback : Callback<Null<M>> ) : Query<M>;
-	public function findByIdAndRemove( id : Dynamic , ?options : {}, ?callback : Callback<Null<M>> ) : Query<M>;
+	public function findByIdAndRemove( ?id : Dynamic , ?options : {}, ?callback : Callback<Null<M>> ) : Query<M>;
 
 	public function count( ?conditions : {}, ?callback : Callback<Int> ): Query<M>;
 

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -2,6 +2,9 @@ package js.npm.mongoose;
 
 import js.support.Callback;
 
+private abstract Either<T1, T2>(Dynamic)
+from T1 from T2 to T1 to T2 {}
+
 @:native("Model")
 extern class TModel<T>
 extends Document<T>
@@ -11,9 +14,9 @@ implements npm.Package.RequireNamespace<"mongoose","*">
 	public var db : Connection;
 	public var collection : Dynamic;//Collection;
 	public var modelName : String;
-	
-	@:overload(function(): Void {})
-	public function save( fn : Callback<TModel<T>> ) : Void;
+
+	@:overload( function( ?fn : Callback<TModel<T>> ) : Void {})
+	public function save( ?fn : Callback2<TModel<T>, Int> ) : Void;
 	public function increment() : TModel<T>;
 	public function remove( ?fn : Callback<TModel<T>> ) : TModel<T>;
 
@@ -38,76 +41,49 @@ extern class TModels<T,M:TModel<T>> {
 	public var schema : Schema<T>;
 	public var base : Mongoose;
 	
-	public function ensureIndexes( ?fn : Callback0 ) : Void;
-	public function remove( conditions : {} , callback : Callback0 ) : Void;
+	public function ensureIndexes( ?fn : Callback0 ) : Promise;
+	public function remove( conditions : {} , ?callback : Callback0 ) : Query<Array<M>>;
 
-	@:overload( function ( conditions : {} , fields : String , callback : Callback<Array<M>> ): Query<Array<M>> {} )
-	@:overload( function ( conditions : {} , fields : String , options : {} , ?callback : Callback<Array<Model<T>>> ): Query<Array<M>> {} )
-	@:overload( function ( conditions : {} , fields : Null<{}> , options : {} , ?callback : Callback<Array<M>> ): Query<Array<M>> {} )
-	public function find( ?conditions : {} , ?callback : Callback<Array<M>> ): Query<Array<M>>; // Query<Model<T>>
+	public function find( ?conditions : {} , ?fields : Either<String, {}>, ?options : {}, ?callback : Callback<Array<M>> ): Query<Array<M>>; // Query<Model<T>>
+	public function findById( id : Dynamic , ?fields : Either<String, {}>, ?options : {}, ?callback : Callback<Null<M>> ): Query<M>; // Query<Model<T>>
+	public function findOne( ?conditions : {} , ?callback : Callback<Null<M>> ): Query<M>;
 
-	@:overload( function( id : Dynamic , callback : Callback<Null<M>> ) : Void {} )
-	@:overload( function ( id : Dynamic , fields : String , options : {} , ?callback : Callback<Null<Model<T>>> ): Query<Model<T>> {} )
-	@:overload( function ( id : Dynamic , fields : Null<{}> , options : {} , ?callback : Callback<Null<Model<T>>> ): Query<Model<T>> {} )
-	public function findById( id : Dynamic , ?callback : Callback<Null<Model<T>>> ): Query<Model<T>>; // Query<Model<T>>
+	public function findOneAndUpdate( ?conditions : {} , ?update : {} , ?options : {} , ?callback : Callback<Null<M>> ) : Query<M>;
+	public function findOneAndRemove( ?conditions : {} , ?options : {} , ?callback : Callback<Null<M>> ) : Query<M>;
 
-	@:overload( function( conditions : {} , callback : Callback<Null<M>> ) : Void {} )
-	@:overload( function ( conditions : {}  , fields : String , options : {} , ?callback : Callback<Null<M>> ): Query<M> {} )
-	@:overload( function ( conditions : {} , fields : Null<{}> , options : {} , ?callback : Callback<Null<M>> ): Query<M> {} )
-	public function findOne( ?conditions : {} ): Query<M>; // Query<M>
+	public function findByIdAndUpdate( ?id : Dynamic , ?update : {} , ?options : {} , ?callback : Callback<Null<M>> ) : Query<M>;
+	public function findByIdAndRemove( id : Dynamic , ?options : {}, ?callback : Callback<Null<M>> ) : Query<M>;
 
-	@:overload( function ( conditions : {} , ?callback : Callback<Int> ): Query<M> {} )// Query<M>
-	public function count( callback : Callback<Int> ): Query<M>; // Query<M>
+	public function count( ?conditions : {}, ?callback : Callback<Int> ): Query<M>;
 
-	@:overload( function ( field : String ): Query<M> {} )// Query<M>
-	@:overload( function ( field : String , conditions : {} , callback : Callback<Array<M>> ): Query<M> {} )// Query<M>
-	@:overload( function ( field : String , conditions : {} ): Query<M> {} )// Query<M>
-	public function distinct( field : String , callback : Callback<Array<M>> ): Query<M>; // Query<M>
+	public function distinct( field : String , ?conditions : {} , ?callback : Callback<Array<M>> ): Query<M>; 
 
 	public function where( field : String , ?val : Dynamic ) : Query<Array<M>>;
 
 	@:overload( function( conditions : Void->Bool ) : Query<Array<M>> {} )
 	public inline function _where( conditions : String ) : Query<Array<M>> return untyped this["$where"](conditions);
 
-	@:overload( function( ) : Query<M> {} )
-	@:overload( function( conditions : {} , update : {} , options : {} , callback : Callback<Null<M>> ) : Query<M> {} )
-	@:overload( function( conditions : {} , update : {} , options : {} ) : Query<M> {} )
-	@:overload( function( conditions : {} , update : {} ) : Query<M> {} )
-	public function findOneAndUpdate( conditions : {} , update : {} , callback : Callback<Null<M>> ) : Query<M>;
+	@:overload( function( doc : Array<T> , fn : Callback<Array<M>> ) : Promise {} )
+	public function create( doc : T , fn : Callback<M> /* TODO : maybe there's a solution for multiple arguments... */  ) : Promise;
 
-	@:overload( function( ) : Query<M> {} )
-	@:overload( function( id : Dynamic , update : {} , options : {} , callback : Callback<Null<M>> ) : Query<M> {} )
-	@:overload( function( id : Dynamic , update : {} , options : {} ) : Query<M> {} )
-	@:overload( function( id : Dynamic , update : {} ) : Query<M> {} )
-	public function findByIdAndUpdate( id : Dynamic , update : {} , callback : Callback<Null<M>> ) : Query<M>;
+	@:overload( function( conditions : {} , update : {} , ?options : {},  ?callback : Callback<Int> ) : Query<Array<M>> {} )
+	public function update( conditions : {} , update : {} , ?options : {},  ?callback : Callback2<Int, Dynamic> ) : Query<Array<M>>;
 
-	@:overload( function( conditions : {} , options : {} , callback : Callback<Null<M>> ) : Query<M> {} )
-	@:overload( function( conditions : {} , options : {} ) : Query<M> {} )
-	@:overload( function( ?conditions : {} ) : Query<M> {} )
-	public function findOneAndRemove( conditions : {} , callback : Callback<Null<M>> ) : Query<M>;
+	@:overload( function( o : ModelMapReduce , ?callback : Callback<Array<M>> ) : Void {} )
+	public function mapReduce( o : ModelMapReduce , ?callback : Callback2<Array<M>,{}> ) : Void;
 
-	@:overload( function( id : Dynamic , options : {} , callback : Callback<Null<M>> ) : Query<M> {} )
-	@:overload( function( id : Dynamic , options : {} ) : Query<M> {} )
-	@:overload( function( ?id : Dynamic ) : Query<M> {} )
-	public function findByIdAndRemove( id : Dynamic , callback : Callback<Null<M>> ) : Query<M>;
+	@:overload( function( c1 : {} , c2 : {} , c3 : {} , c4 : {} , c5 : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )
+	@:overload( function( c1 : {} , c2 : {} , c3 : {} , c4 : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )
+	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )
+	@:overload( function( c1 : {} , c2 : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )
+	@:overload( function( commands : {} , options : {} , ?callback : Callback<{}> ) : Dynamic {} )
+	public function aggregate( commands : {} , ?callback : Callback<{}> ) : Dynamic; // Either<Aggregate, Promise>
 
-	@:overload( function( doc : Array<T> , fn : Callback<Array<M>> ) : Void {} )
-	public function create( doc:T , fn : Callback<M> /* TODO : maybe there's a solution for multiple arguments... */  ) : Void;
+	@:overload(function( doc : Dynamic , options : {} , ?cb : Callback<M> ) : Promise {} )
+	public function populate( docs : Array<Dynamic> , options : {} , ?cb : Callback<Array<M>> ) : Promise;
 
-	@:overload( function( conditions : {} , update : {} , options : {} , callback : Callback<Array<M>> ) : Query<Array<M>> {} )
-	@:overload( function( conditions : {} , update : {} , options : {} ) : Query<Array<M>> {} )
-	@:overload( function( conditions : {} , update : {} ) : Query<Array<M>> {} )
-	public function update( conditions : {} , update : {} , callback : Callback<Array<M>> ) : Query<Array<M>>;
-
-	public function mapReduce( o : ModelMapReduce , callback : Callback2<Array<M>,{}> ) : Void;
-
-	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , callback : Callback<{}> ) : Void {} )
-	@:overload( function( c1 : {} , c2 : {} , options : {} , callback : Callback<{}> ) : Void {} )
-	@:overload( function( commands : {} , options : {} , callback : Callback<{}> ) : Void {} )
-	public function aggregate( commands : {} , callback : Callback<{}> ) : Void;
-
-	@:overload(function( doc : {} , options : {} , cb : Callback<M> ) : Void {} )
-	public function populate( docs : Array<{}> , options : {} , cb : Callback<Array<M>> ) : Void;
+	public function geoNear(geoJSON : Either<{}, Array<Float>>, ?options : {}, ?cb : Callback2<Array<M>, Dynamic>) : Promise;
+	public function geoSearch(condition : {}, options : {}, ?cb : Callback<Array<M>>) : Promise;
 
 	public inline function construct( ?doc : T ) : M {
 		return untyped __new__(this,doc);

--- a/js/support/Either.hx
+++ b/js/support/Either.hx
@@ -1,0 +1,16 @@
+package js.support;
+
+abstract Either<T1, T2>(Dynamic)
+from T1 to T1 
+from T2 to T2 {}
+
+abstract Either3<T1, T2, T3>(Dynamic)
+from T1 to T1 
+from T2 to T2
+from T3 to T3 {}
+
+abstract Either4<T1, T2, T3, T4>(Dynamic)
+from T1 to T1 
+from T2 to T2
+from T3 to T3 
+from T4 to T4 {}


### PR DESCRIPTION
Because Haxe can assign optional arguments in any order if the type is correct (http://haxe.org/manual/types-function-optional-arguments.html), I was able to clean up the model class pretty good. 

Also added an `Either<A,B>` abstract class for some additional simplification.