### PR TITLE
Need to @:forward the error class to enable field access.

### DIFF
--- a/js/support/Error.hx
+++ b/js/support/Error.hx
@@ -1,5 +1,6 @@
 package js.support;
 
+@:forward
 abstract Error( Dynamic )
 from js.Error to js.Error
 from String to String {


### PR DESCRIPTION
This is required so you can access for example `err.message` on the error object.