### PR TITLE
Adding @cb metadata, for more converient callback argument handling.

### DIFF
--- a/util/Async.hx
+++ b/util/Async.hx
@@ -18,6 +18,7 @@ class AsyncBuilder {
 	#if macro
 
 		public static inline var asyncMeta = "async";
+		public static inline var cbMeta = "cb";
 
 		static function build(){
 			var fields : Array<Field> = haxe.macro.Context.getBuildFields();
@@ -50,6 +51,16 @@ class AsyncBuilder {
 						
 					}
 					e.expr = EBlock( currentBlock );
+
+				case EMeta(s, em) if (s.name == cbMeta):
+					if (s.params.length == 0) s.params.push(macro cb);
+					switch(em.expr) {
+						case ECall(e1, params):
+							for(i in 0...s.params.length)
+								params.push(s.params[i]);
+						case _:
+					}
+					e.iter(transform.bind(_, block));
 
 				case EVars( vars ) :
 					//var newVars = [];


### PR DESCRIPTION
Here's an idea I got after using the `@async` feature. It is perfect for returning values, but for async loop behavior the [Async](https://github.com/caolan/async) library is quite nice. However, if you're just passing the callback to the previous call it can get a bit clumsy:

```haxe
function passTheError(cb : Callback0) {
	// ...
	Async.eachSeries(someArray, function(item, cb) {
		// ...
		Async.each([function(cb) {
			// ...
		}], cb);
	}, cb);
}
```

Keeping track of the `cb` at the end of the loop ruins the readability. This PR adds an extra feature to util.Async, a `@cb` metadata, turning the above code into:

```haxe
function passTheError(cb : Callback0) {
	// ...
	@cb Async.eachSeries(someArray, function(item, cb) {
		// ...
		@cb Async.each([function(cb) {
			// ...
		}]);
	});
}
```

`@cb` moves the argument to the top, making it look even more similar to a normal loop. And if your callback isn't named `cb`, you can pass its name (and other arguments) as parameters:

```haxe
@cb(someFunction, callback) Async.eachSeries(someArray);
// becomes:
Async.eachSeries(someArray, someFunction, callback);
```

What do you think? An alternative to `@cb` could be `@loop`, but I don't think it brings any more clarity than cb, and a longer name is probably tedious. Let me know if you have other name suggestions.
