### PR TITLE
Added "equals" function on ObjectId

### DIFF
--- a/js/npm/mongoose/schema/types/ObjectId.hx
+++ b/js/npm/mongoose/schema/types/ObjectId.hx
@@ -5,4 +5,5 @@ extern class ObjectId
 extends js.npm.mongoose.SchemaType
 implements npm.Package.RequireNamespace<"mongoose","^4.0.0"> {
 	public function new( path : String , options : {} ) : Void;
+	public function equals(id : ObjectId) : Bool;
 }


### PR DESCRIPTION
Equals function is required to compare two ObjectIds without casting them to strings.