### PR TITLE
Removed haxe.extern from functions declaration as it breaks completion

### DIFF
--- a/js/npm/express/Application.hx
+++ b/js/npm/express/Application.hx
@@ -1,7 +1,7 @@
 package js.npm.express;
 
 import js.support.Callback;
-
+import haxe.extern.Rest;
 import js.npm.express.Middleware;
 
 extern class Application
@@ -19,7 +19,7 @@ extends MiddlewareHttp
 	function engine( ext : String , engine : ViewEngine ) : Application;
 	function set( setting : String , value : Dynamic ) : Application;
 
-	@:overload( function ( path : Route, f : haxe.extern.Rest<AbstractMiddleware> ) : Application {} )
-	@:overload( function ( f : haxe.extern.Rest<AbstractMiddleware> ) : Application {} )
+	@:overload( function ( path : Route, f : Rest<AbstractMiddleware> ) : Application {} )
+	@:overload( function ( f : Rest<AbstractMiddleware> ) : Application {} )
 	function get( setting : String ): Dynamic;
 }

--- a/js/npm/express/Middleware.hx
+++ b/js/npm/express/Middleware.hx
@@ -5,9 +5,9 @@ import js.support.Callback;
 
 extern interface Middleware {}
 
-abstract AbstractMiddleware( Dynamic ) 
-from MiddlewareErrorHandler to MiddlewareErrorHandler 
-from MiddlewareResponder to MiddlewareResponder 
+abstract AbstractMiddleware( Dynamic )
+from MiddlewareErrorHandler to MiddlewareErrorHandler
+from MiddlewareResponder to MiddlewareResponder
 from MiddlewareHandler to MiddlewareHandler
 from Middleware to Middleware {}
 
@@ -19,35 +19,35 @@ typedef MiddlewareParam<P> = Request -> Response -> MiddlewareNext -> P -> Void;
 typedef MiddlewareMethod = Route->Middleware->Void;
 
 @:build( util.CopyMethods.build([
-	'post', 
-	'put', 
-	'head', 
-	'delete', 
-	'options', 
-	'trace', 
-	'copy', 
-	'lock', 
-	'mkcol', 
-	'move', 
-	'purge', 
-	'propfind', 
-	'proppatch', 
-	'unlock', 
-	'report', 
-	'mkactivity', 
-	'checkout', 
-	'merge', 
+	'post',
+	'put',
+	'head',
+	'delete',
+	'options',
+	'trace',
+	'copy',
+	'lock',
+	'mkcol',
+	'move',
+	'purge',
+	'propfind',
+	'proppatch',
+	'unlock',
+	'report',
+	'mkactivity',
+	'checkout',
+	'merge',
 	'm-search',
-	'notify', 
-	'subscribe', 
-	'unsubscribe', 
-	'patch', 
-	'search', 
+	'notify',
+	'subscribe',
+	'unsubscribe',
+	'patch',
+	'search',
 	'connect',
 	'all'
-], 
-function(path : Route , f : haxe.extern.Rest<AbstractMiddleware>) : MiddlewareHttp {} , [] ) )
-extern class MiddlewareHttp 
+],
+function(path : Route , f : Rest<AbstractMiddleware>) : MiddlewareHttp {} , [] ) )
+extern class MiddlewareHttp
 {
 	@:overload( function ( path : Route , middleware : Rest<AbstractMiddleware> ) : MiddlewareHttp {} )
 	public function use ( middleware : Rest<AbstractMiddleware> ) : MiddlewareHttp ;
@@ -56,33 +56,33 @@ extern class MiddlewareHttp
 }
 
 @:build( util.CopyMethods.build([
-	'get', 
-	'post', 
-	'put', 
-	'head', 
-	'delete', 
-	'options', 
-	'trace', 
-	'copy', 
-	'lock', 
-	'mkcol', 
-	'move', 
-	'purge', 
-	'propfind', 
-	'proppatch', 
-	'unlock', 
-	'report', 
-	'mkactivity', 
-	'checkout', 
-	'merge', 
+	'get',
+	'post',
+	'put',
+	'head',
+	'delete',
+	'options',
+	'trace',
+	'copy',
+	'lock',
+	'mkcol',
+	'move',
+	'purge',
+	'propfind',
+	'proppatch',
+	'unlock',
+	'report',
+	'mkactivity',
+	'checkout',
+	'merge',
 	'm-search',
-	'notify', 
-	'subscribe', 
-	'unsubscribe', 
-	'patch', 
-	'search', 
+	'notify',
+	'subscribe',
+	'unsubscribe',
+	'patch',
+	'search',
 	'connect',
 	'all'
-], 
-function(f : haxe.extern.Rest<AbstractMiddleware>) : MiddlewareRoute {} , [] ) )
+],
+function(f : Rest<AbstractMiddleware>) : MiddlewareRoute {} , [] ) )
 extern class MiddlewareRoute { }

--- a/js/npm/express/Router.hx
+++ b/js/npm/express/Router.hx
@@ -1,8 +1,9 @@
 package js.npm.express;
 import js.npm.express.Middleware;
 import js.support.Callback;
+import haxe.extern.Rest;
 
-extern class Router 
+extern class Router
 extends MiddlewareHttp
 implements Middleware
 implements Dynamic<MiddlewareMethod>
@@ -11,7 +12,7 @@ implements npm.Package.RequireNamespace<"express","~4.0">
 	@:selfCall
 	public function new(? option : { ? caseSensitive : Bool, ? mergeParams : Bool, ? strict : Bool }) : Void;
 
-	@:overload(function(path : Route , f : haxe.extern.Rest<AbstractMiddleware>) : Router {})
+	@:overload(function(path : Route , f : Rest<AbstractMiddleware>) : Router {})
 	@:overload(function (setting : String): Dynamic { } )
 	function get(path : Route, f : AbstractMiddleware) : Router;
 


### PR DESCRIPTION
I had some problems with autocompletion and found out this issue : https://github.com/HaxeFoundation/haxe/issues/4535

I removed all have.extern from functions declaration and added it as an import when needed.

Works as intended.

Fixes : #86