### PR TITLE
Resulting values of a mapReduce don't have to be the model

### DIFF
--- a/js/npm/Mongoose.hx
+++ b/js/npm/Mongoose.hx
@@ -16,4 +16,7 @@ implements npm.Package.Require<"mongoose","^4.2.2"> {
 	static function __init__() : Void 
 		mongoose = untyped Mongoose;
 	
+	public static inline function emit<K, V>(key : K, value : V) : Void {
+		untyped __js__('emit')( key, value );
+	}
 }

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -117,7 +117,7 @@ extern class TModels<T,M:TModel<T>> {
 	@:overload( function( conditions : {} , update : {} ) : Query<Array<M>> {} )
 	public function update( conditions : {} , update : {} , options : ModelUpdateOptions , callback : ModelUpdateCallback ) : Query<Array<M>>;
 
-	public function mapReduce( o : ModelMapReduce , callback : Callback2<Array<M>,{}> ) : Void;
+	public function mapReduce( o : ModelMapReduce , callback : Callback2<Array<Dynamic>,{}> ) : Void;
 
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
 	@:overload( function( c1 : {} , c2 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -117,7 +117,7 @@ extern class TModels<T,M:TModel<T>> {
 	@:overload( function( conditions : {} , update : {} ) : Query<Array<M>> {} )
 	public function update( conditions : {} , update : {} , options : ModelUpdateOptions , callback : ModelUpdateCallback ) : Query<Array<M>>;
 
-	public function mapReduce<R>( o : ModelMapReduce<R> , callback : Callback2<Array<R>,{}> ) : Void;
+	public function mapReduce<M, R>( o : ModelMapReduce<M, R> , callback : Callback2<Array<R>,{}> ) : Void;
 
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
 	@:overload( function( c1 : {} , c2 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
@@ -133,9 +133,9 @@ extern class TModels<T,M:TModel<T>> {
 
 }
 
-typedef ModelMapReduce<R> = {
+typedef ModelMapReduce<M, R> = {
 	map : Void->Void,
-	reduce : String->Array<Dynamic>->R,
+	reduce : String->Array<M>->R,
 	?query : {},
 	?sort : {},
 	?limit : Int,

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -137,11 +137,13 @@ typedef ModelMapReduce = {
 	map : Void->Void,
 	reduce : String->Array<Dynamic>->Void,
 	?query : {},
+	?sort : {},
 	?limit : Int,
 	?keeptemp : Bool,
 	?finalize : Void->Void,
 	?scope : {},
 	?jsMode : Bool,
 	?verbose : Bool,
+	?readPreference : String,
 	?out : {}
 }

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -117,7 +117,7 @@ extern class TModels<T,M:TModel<T>> {
 	@:overload( function( conditions : {} , update : {} ) : Query<Array<M>> {} )
 	public function update( conditions : {} , update : {} , options : ModelUpdateOptions , callback : ModelUpdateCallback ) : Query<Array<M>>;
 
-	public function mapReduce( o : ModelMapReduce , callback : Callback2<Array<Dynamic>,{}> ) : Void;
+	public function mapReduce<R>( o : ModelMapReduce<R> , callback : Callback2<Array<R>,{}> ) : Void;
 
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
 	@:overload( function( c1 : {} , c2 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
@@ -133,9 +133,9 @@ extern class TModels<T,M:TModel<T>> {
 
 }
 
-typedef ModelMapReduce = {
+typedef ModelMapReduce<R> = {
 	map : Void->Void,
-	reduce : String->Array<Dynamic>->Void,
+	reduce : String->Array<Dynamic>->R,
 	?query : {},
 	?sort : {},
 	?limit : Int,


### PR DESCRIPTION
It's more correct to define a Dynamic array of results instead of a model array because in the map function you may returns any possible value.