### PR TITLE
Fixed reference to mongoose instance

### DIFF
--- a/util/Mongoose.hx
+++ b/util/Mongoose.hx
@@ -75,7 +75,7 @@ class Mongoose {
 						params : [],
 						expr : macro {
 
-							var m = untyped mongoose.model( name , $modExpr.get_Schema() , collectionName , skipInit );
+							var m = untyped js.npm.Mongoose.mongoose.model( name , $modExpr.get_Schema() , collectionName , skipInit );
 							var proto = untyped $modelExpr.prototype;
 							for( f in Reflect.fields(proto) ){
 								untyped m[f] = proto[f];


### PR DESCRIPTION
After updating to mongoose 4.4.3 I had to specify the full path to haxe mongoose instance to be able to use managers at runtime.
Otherwise, I got errors like `create is not a function`.