### PR TITLE
Added Aggregate class and more find() prototypes

### DIFF
--- a/js/npm/mongoose/Aggregate.hx
+++ b/js/npm/mongoose/Aggregate.hx
@@ -1,0 +1,53 @@
+package js.npm.mongoose;
+
+import haxe.extern.Rest;
+import js.support.Callback;
+
+extern class Aggregate<M>
+implements npm.Package.RequireNamespace<"mongoose", "^4.0.0">
+{
+    public var options : Dynamic;
+
+    @:overload(function (commands : Rest<{}>) : Void {})
+    @:overload(function (commands : Array<{}>) : Void {})
+    public function new();
+
+    public function model(model : M) : Aggregate<M>;
+
+    @:overload(function (commands : Rest<{}>) : Aggregate<M> {})
+    public function append(commands : Array<{}>) : Aggregate<M>;
+
+    @:overload(function (selection : {}) : Aggregate<M> {})
+    public function project(selection : String) : Aggregate<M>;
+
+    public function near(args : {}) : Aggregate<M>;
+
+    public function group(args : {}) : Aggregate<M>;
+
+    public function match(args : {}) : Aggregate<M>;
+
+    public function skip(args : {}) : Aggregate<M>;
+
+    public function limit(args : {}) : Aggregate<M>;
+
+    public function out(args : {}) : Aggregate<M>;
+
+    public function unwind(args : Rest<String>) : Aggregate<M>;
+
+    public function lookup(args : {}) : Aggregate<M>;
+
+    public function sample(size : Int) : Aggregate<M>;
+
+    @:overload(function (selection : {}) : Aggregate<M> {})
+    public function sort(selection : String) : Aggregate<M>;
+
+    public function read(pref : String, ?tags : Array<String>) : Aggregate<M>;
+
+    public function explain(cb : Callback<{}>) : Promise;
+
+    public function allowDiskUse(value : Bool) : Aggregate<M>;
+
+    public function cursor(options : {}) : Aggregate<M>;
+
+    public function exec(callback : Callback<Array<{}>>) : Promise;
+}

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -1,5 +1,6 @@
 package js.npm.mongoose;
 
+import haxe.extern.Rest;
 import js.support.Callback;
 import js.support.Error;
 
@@ -121,7 +122,7 @@ extern class TModels<T,M:TModel<T>> {
 	public function mapReduce<M, R>( o : ModelMapReduce<M, R> , callback : Callback2<Array<R>,{}> ) : Void;
 
 	@:overload( function() : Aggregate<M> {} )
-	@:overload( function( commands : haxe.extern.Rest<{}> ) : Aggregate<M> {} )
+	@:overload( function( commands : Rest<{}> ) : Aggregate<M> {} )
 	@:overload( function( commands : Array<{}> ) : Aggregate<M> {} )
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
 	@:overload( function( c1 : {} , c2 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )

--- a/js/npm/mongoose/Model.hx
+++ b/js/npm/mongoose/Model.hx
@@ -61,6 +61,7 @@ extern class TModels<T,M:TModel<T>> {
 
 	@:overload( function ( conditions : {} , fields : String , callback : Callback<Array<M>> ): Query<Array<M>> {} )
 	@:overload( function ( conditions : {} , fields : String , options : {} , ?callback : Callback<Array<Model<T>>> ): Query<Array<M>> {} )
+	@:overload( function ( conditions : {} , fields : Null<{}> , ?callback : Callback<Array<M>> ): Query<Array<M>> {} )
 	@:overload( function ( conditions : {} , fields : Null<{}> , options : {} , ?callback : Callback<Array<M>> ): Query<Array<M>> {} )
 	public function find( ?conditions : {} , ?callback : Callback<Array<M>> ): Query<Array<M>>; // Query<Model<T>>
 
@@ -119,6 +120,9 @@ extern class TModels<T,M:TModel<T>> {
 
 	public function mapReduce<M, R>( o : ModelMapReduce<M, R> , callback : Callback2<Array<R>,{}> ) : Void;
 
+	@:overload( function() : Aggregate<M> {} )
+	@:overload( function( commands : haxe.extern.Rest<{}> ) : Aggregate<M> {} )
+	@:overload( function( commands : Array<{}> ) : Aggregate<M> {} )
 	@:overload( function( c1 : {} , c2 : {} , c3 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
 	@:overload( function( c1 : {} , c2 : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )
 	@:overload( function( commands : {} , options : {} , callback : Callback<Array<{}>> ) : Void {} )


### PR DESCRIPTION
Without callbacks, `aggregate` method returns an Aggregate instance.