### PR TITLE
Fixed return values, now Dynamic where appropriate.

### DIFF
--- a/js/npm/arangojs/Collection.hx
+++ b/js/npm/arangojs/Collection.hx
@@ -27,42 +27,42 @@ extern class Collection
 {
 	// Getting information about the collection
 
-	public function get(cb : ArangoCallback<{}>) : Void;
-	public function properties(cb : ArangoCallback<{}>) : Void;
+	public function get(cb : ArangoCallback<Dynamic>) : Void;
+	public function properties(cb : ArangoCallback<Dynamic>) : Void;
 	public function count(cb : ArangoCallback<Int>) : Void;
-	public function figures(cb : ArangoCallback<{}>) : Void;
+	public function figures(cb : ArangoCallback<Dynamic>) : Void;
 	public function revision(cb : ArangoCallback<String>) : Void;	
-	@:overload(function(cb : ArangoCallback<{}>) : Void {})
-	public function checksum(opts : {}, cb : ArangoCallback<{}>) : Void;
+	@:overload(function(cb : ArangoCallback<Dynamic>) : Void {})
+	public function checksum(opts : {}, cb : ArangoCallback<Dynamic>) : Void;
 
 	// Manipulating the collection
 
-	@:overload(function(cb : ArangoCallback<{}>) : Void {})
-	public function create(properties : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(cb : ArangoCallback<{}>) : Void {})
-	public function load(count : Bool, cb : ArangoCallback<{}>) : Void;
-	public function unload(cb : ArangoCallback<{}>) : Void;
-	public function setProperties(properties : {}, cb : ArangoCallback<{}>) : Void;
-	public function rename(name : String, cb : ArangoCallback<{}>) : Void;
-	public function rotate(cb : ArangoCallback<{}>) : Void;
-	public function truncate(cb : ArangoCallback<{}>) : Void;
-	public function drop(cb : ArangoCallback<{}>) : Void;
+	@:overload(function(cb : ArangoCallback<Dynamic>) : Void {})
+	public function create(properties : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(cb : ArangoCallback<Dynamic>) : Void {})
+	public function load(count : Bool, cb : ArangoCallback<Dynamic>) : Void;
+	public function unload(cb : ArangoCallback<Dynamic>) : Void;
+	public function setProperties(properties : {}, cb : ArangoCallback<Dynamic>) : Void;
+	public function rename(name : String, cb : ArangoCallback<Dynamic>) : Void;
+	public function rotate(cb : ArangoCallback<Dynamic>) : Void;
+	public function truncate(cb : ArangoCallback<Dynamic>) : Void;
+	public function drop(cb : ArangoCallback<Dynamic>) : Void;
 
 	// Manipulating indexes
 
-	public function createIndex(details : {}, cb : ArangoCallback<{}>) : Void;
-	public function createCapConstraint(size : { }, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(fields : Array<String>, cb : ArangoCallback<{}>) : Void {})
-	public function createHashIndex(fields : Array<String>, opts : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(fields : Array<String>, cb : ArangoCallback<{}>) : Void {})
-	public function createSkipList(fields : Array<String>, opts : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(fields : Array<String>, cb : ArangoCallback<{}>) : Void {})
-	public function createGeoIndex(fields : Array<String>, opts : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(fields : Array<String>, cb : ArangoCallback<{}>) : Void {})
-	public function createFulltextIndex(fields : Array<String>, minLength : Int, cb : ArangoCallback<{}>) : Void;
-	public function index(indexHandle : String, cb : ArangoCallback<{}>) : Void;
-	public function indexes(cb : ArangoCallback<Array<{}>>) : Void;
-	public function dropIndex(indexHandle : String, cb : ArangoCallback<{}>) : Void;
+	public function createIndex(details : {}, cb : ArangoCallback<Dynamic>) : Void;
+	public function createCapConstraint(size : { }, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(fields : Array<String>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function createHashIndex(fields : Array<String>, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(fields : Array<String>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function createSkipList(fields : Array<String>, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(fields : Array<String>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function createGeoIndex(fields : Array<String>, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(fields : Array<String>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function createFulltextIndex(fields : Array<String>, minLength : Int, cb : ArangoCallback<Dynamic>) : Void;
+	public function index(indexHandle : String, cb : ArangoCallback<Dynamic>) : Void;
+	public function indexes(cb : ArangoCallback<Array<Dynamic>>) : Void;
+	public function dropIndex(indexHandle : String, cb : ArangoCallback<Dynamic>) : Void;
 
 	// Simple queries
 
@@ -77,15 +77,15 @@ extern class Collection
 	public function byExample<T>(example : {}, opts : {}, cb : ArangoCallback<Cursor<T>>) : Void;
 	public function firstExample<T>(example : {}, cb : ArangoCallback<T>) : Void;
 
-	@:overload(function(example : {}, cb : ArangoCallback<{}>) : Void {})
-	public function removeByExample(example : {}, opts : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(example : {}, newValue : {}, cb : ArangoCallback<{}>) : Void {})
-	public function replaceByExample(example : {}, newValue : {}, opts : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(example : {}, newValue : {}, cb : ArangoCallback<{}>) : Void {})
-	public function updateByExample(example : {}, newValue : {}, opts : {}, cb : ArangoCallback<{}>) : Void;
-	public function lookupByKeys(keys : Array<String>, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(keys : Array<String>, cb : ArangoCallback<{}>) : Void {})
-	public function removeByKeys(keys : Array<String>, opts : {}, cb : ArangoCallback<{}>) : Void;
+	@:overload(function(example : {}, cb : ArangoCallback<Dynamic>) : Void {})
+	public function removeByExample(example : {}, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(example : {}, newValue : {}, cb : ArangoCallback<Dynamic>) : Void {})
+	public function replaceByExample(example : {}, newValue : {}, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(example : {}, newValue : {}, cb : ArangoCallback<Dynamic>) : Void {})
+	public function updateByExample(example : {}, newValue : {}, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
+	public function lookupByKeys(keys : Array<String>, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(keys : Array<String>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function removeByKeys(keys : Array<String>, opts : {}, cb : ArangoCallback<Dynamic>) : Void;
 
 	@:overload(function<T>(fieldName : String, query : String, cb : ArangoCallback<Cursor<T>>) : Void {})
 	public function fulltext<T>(fieldName : String, query : String, opts : {}, cb : ArangoCallback<Cursor<T>>) : Void;

--- a/js/npm/arangojs/Database.hx
+++ b/js/npm/arangojs/Database.hx
@@ -19,9 +19,9 @@ typedef Aqb = String;
 extern class Database
 implements npm.Package.RequireNamespace<"arangojs", "^4.3.0">
 {
+	@:overload(function() : Database {})
 	@:overload(function(config : String) : Database {})
-	@:overload(function(config : DatabaseOptions) : Database {})
-	public function new();
+	public function new(config : DatabaseOptions);
 
 	// Manipulating databases
 
@@ -72,6 +72,7 @@ implements npm.Package.RequireNamespace<"arangojs", "^4.3.0">
 	
 	// Arbitrary HTTP routes
 	
+	@:overload(function() : Route {})
 	@:overload(function(headers : {}) : Route {})
 	@:overload(function(path : String) : Route {})
 	public function route(path : String, headers : {}) : Route;

--- a/js/npm/arangojs/Database.hx
+++ b/js/npm/arangojs/Database.hx
@@ -26,35 +26,35 @@ implements npm.Package.RequireNamespace<"arangojs", "^4.3.0">
 	// Manipulating databases
 
 	public function useDatabase(databaseName : String) : Database;
-	@:overload(function(databaseName : String, cb : ArangoCallback<{}>) : Void {})
-	public function createDatabase(databaseName : String, users : Array<Dynamic>, cb : ArangoCallback<{}>) : Void;
-	public function get(cb : ArangoCallback<{}>) : Void;
+	@:overload(function(databaseName : String, cb : ArangoCallback<Dynamic>) : Void {})
+	public function createDatabase(databaseName : String, users : Array<Dynamic>, cb : ArangoCallback<Dynamic>) : Void;
+	public function get(cb : ArangoCallback<Dynamic>) : Void;
 	public function listDatabases(cb : ArangoCallback<Array<String>>) : Void;
 	public function listUserDatabases(cb : ArangoCallback<Array<String>>) : Void;
-	public function dropDatabase(databaseName : String, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(cb : ArangoCallback<{}>) : Void {})
-	public function truncate(excludeSystem : Bool, cb : ArangoCallback<{}>) : Void;
+	public function dropDatabase(databaseName : String, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(cb : ArangoCallback<Dynamic>) : Void {})
+	public function truncate(excludeSystem : Bool, cb : ArangoCallback<Dynamic>) : Void;
 
 	// Accessing collections
 	
 	public function collection(collectionName : String) : DocumentCollection;
 	public function edgeCollection(collectionName : String) : EdgeCollection;
-	@:overload(function(cb : ArangoCallback<Array<{}>>) : Void {})
-	public function listCollections(excludeSystem : Bool, cb : ArangoCallback<Array<{}>>) : Void;
+	@:overload(function(cb : ArangoCallback<Array<Dynamic>>) : Void {})
+	public function listCollections(excludeSystem : Bool, cb : ArangoCallback<Array<Dynamic>>) : Void;
 	@:overload(function(cb : ArangoCallback<Array<Collection>>) : Void {})
 	public function collections(excludeSystem : Bool, cb : ArangoCallback<Array<Collection>>) : Void;
 	
 	// Accessing graphs
 
 	public function graph(graphName : String) : Graph;
-	public function listGraphs(cb : ArangoCallback<Array<{}>>) : Void;
+	public function listGraphs(cb : ArangoCallback<Array<Dynamic>>) : Void;
 	public function graphs(cb : ArangoCallback<Array<Graph>>) : Void;
 
 	// Transactions
 	
-	@:overload(function(collections : Either3<String, {}, Array<String>>, action : String, cb : ArangoCallback<{}>) : Void {})
-	@:overload(function(collections : Either3<String, {}, Array<String>>, action : String, params : Array<{}>, cb : ArangoCallback<{}>) : Void {})
-	public function transaction(collections : Either3<String, {}, Array<String>>, action : String, params : Array<{}>, lockTimeout : Int, cb : ArangoCallback<{}>) : Void;
+	@:overload(function(collections : Either3<String, {}, Array<String>>, action : String, cb : ArangoCallback<Dynamic>) : Void {})
+	@:overload(function(collections : Either3<String, {}, Array<String>>, action : String, params : Array<{}>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function transaction(collections : Either3<String, {}, Array<String>>, action : String, params : Array<{}>, lockTimeout : Int, cb : ArangoCallback<Dynamic>) : Void;
 	
 	// Queries
 	// aqlQuery macro
@@ -65,10 +65,10 @@ implements npm.Package.RequireNamespace<"arangojs", "^4.3.0">
 
 	// Managing AQL user functions
 	
-	public function listFunctions(cb : ArangoCallback<Array<{}>>) : Void;
-	public function createFunction(name : String, code : String, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(name : String, cb : ArangoCallback<{}>) : Void {})
-	public function dropFunction(name : String, group : String, cb : ArangoCallback<{}>) : Void;
+	public function listFunctions(cb : ArangoCallback<Array<Dynamic>>) : Void;
+	public function createFunction(name : String, code : String, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(name : String, cb : ArangoCallback<Dynamic>) : Void {})
+	public function dropFunction(name : String, group : String, cb : ArangoCallback<Dynamic>) : Void;
 	
 	// Arbitrary HTTP routes
 	

--- a/js/npm/arangojs/EdgeCollection.hx
+++ b/js/npm/arangojs/EdgeCollection.hx
@@ -4,10 +4,10 @@ import js.support.Either;
 extern class EdgeCollection extends Collection
 {
 	public function edge<T>(documentHandle : Either<String, {}>, cb : ArangoCallback<T>) : Void;
-	@:overload(function<T>(data : T, fromId : Either<String, {}>, toId : Either<String, {}>, cb : ArangoCallback<{}>) : Void {})
-	public function save<T>(data : T, cb : ArangoCallback<{}>) : Void;
-	public function edges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<{}>>) : Void;
-	public function inEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<{}>>) : Void;
-	public function outEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<{}>>) : Void;
+	@:overload(function<T>(data : T, fromId : Either<String, {}>, toId : Either<String, {}>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function save<T>(data : T, cb : ArangoCallback<Dynamic>) : Void;
+	public function edges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<Dynamic>>) : Void;
+	public function inEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<Dynamic>>) : Void;
+	public function outEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<Dynamic>>) : Void;
 	public function traversal<T>(startVertex : Either<String, {}>, opts : {}, cb : ArangoCallback<T>) : Void;
 }

--- a/js/npm/arangojs/Graph.hx
+++ b/js/npm/arangojs/Graph.hx
@@ -11,21 +11,21 @@ typedef EdgeDefinition = {
 
 extern class Graph 
 {
-	public function get(cb : ArangoCallback<{}>) : Void;
-	public function create(properties : {}, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(cb : ArangoCallback<{}>) : Void {})
-	public function drop(dropCollections : Bool, cb : ArangoCallback<{}>) : Void;
+	public function get(cb : ArangoCallback<Dynamic>) : Void;
+	public function create(properties : {}, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(cb : ArangoCallback<Dynamic>) : Void {})
+	public function drop(dropCollections : Bool, cb : ArangoCallback<Dynamic>) : Void;
 
 	public function vertexCollection(collectionName : String) : GraphVertexCollection;
-	public function addVertexCollection(collectionName : String, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(collectionName : String, cb : ArangoCallback<{}>) : Void {})
-	public function removeVertexCollection(collectionName : String, dropCollection : Bool, cb : ArangoCallback<{}>) : Void;
+	public function addVertexCollection(collectionName : String, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(collectionName : String, cb : ArangoCallback<Dynamic>) : Void {})
+	public function removeVertexCollection(collectionName : String, dropCollection : Bool, cb : ArangoCallback<Dynamic>) : Void;
 
 	public function edgeCollection(collectionName : String) : GraphEdgeCollection;
-	public function addEdgeDefinition(definition : EdgeDefinition, cb : ArangoCallback<{}>) : Void;
-	public function replaceEdgeDefinition(collectionName : String, definition : EdgeDefinition, cb : ArangoCallback<{}>) : Void;
-	@:overload(function(definitionName : String, cb : ArangoCallback<{}>) : Void {})
-	public function removeEdgeDefinition(definitionName : String, dropCollection : Bool, cb : ArangoCallback<{}>) : Void;	
+	public function addEdgeDefinition(definition : EdgeDefinition, cb : ArangoCallback<Dynamic>) : Void;
+	public function replaceEdgeDefinition(collectionName : String, definition : EdgeDefinition, cb : ArangoCallback<Dynamic>) : Void;
+	@:overload(function(definitionName : String, cb : ArangoCallback<Dynamic>) : Void {})
+	public function removeEdgeDefinition(definitionName : String, dropCollection : Bool, cb : ArangoCallback<Dynamic>) : Void;	
 	
-	public function traversal<T>(startVertex : String, opts : { }, cb : ArangoCallback<T>) : Void;
+	public function traversal<T>(startVertex : String, opts : {}, cb : ArangoCallback<T>) : Void;
 }

--- a/js/npm/arangojs/GraphEdgeCollection.hx
+++ b/js/npm/arangojs/GraphEdgeCollection.hx
@@ -4,10 +4,10 @@ import js.support.Either;
 extern class GraphEdgeCollection extends Collection
 {
 	public function edge<T>(documentHandle : Either<String, {}>, cb : ArangoCallback<T>) : Void;
-	@:overload(function<T>(data : T, fromId : Either<String, {}>, toId : Either<String, {}>, cb : ArangoCallback<{}>) : Void {})
-	public function save<T>(data : T, cb : ArangoCallback<{}>) : Void;
-	public function edges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<{}>>) : Void;
-	public function inEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<{}>>) : Void;
-	public function outEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<{}>>) : Void;	
+	@:overload(function<T>(data : T, fromId : Either<String, {}>, toId : Either<String, {}>, cb : ArangoCallback<Dynamic>) : Void {})
+	public function save<T>(data : T, cb : ArangoCallback<Dynamic>) : Void;
+	public function edges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<Dynamic>>) : Void;
+	public function inEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<Dynamic>>) : Void;
+	public function outEdges(documentHandle : Either<String, {}>, cb : ArangoCallback<Array<Dynamic>>) : Void;	
 	public function traversal<T>(startVertex : Either<String, {}>, opts : {}, cb : ArangoCallback<T>) : Void;
 }

--- a/js/npm/arangojs/GraphVertexCollection.hx
+++ b/js/npm/arangojs/GraphVertexCollection.hx
@@ -4,5 +4,5 @@ import js.support.Either;
 extern class GraphVertexCollection extends Collection
 {
 	public function vertex<T>(documentHandle : Either<String, {}>, cb : ArangoCallback<T>) : Void;
-	public function save(data : {}, cb : ArangoCallback<{}>) : Void;
+	public function save(data : {}, cb : ArangoCallback<Dynamic>) : Void;
 }

--- a/js/npm/arangojs/Route.hx
+++ b/js/npm/arangojs/Route.hx
@@ -1,4 +1,52 @@
 package js.npm.arangojs;
 
-// https://github.com/arangodb/arangojs#route-api
-extern class Route implements Dynamic {}
+import js.support.Either;
+
+typedef RouteRequestOptions = {
+	?path : String,
+	?absolutePath : Bool,
+	?body : Either<String, {}>,
+	?qs : Either<String, {}>,
+	?headers : {},
+	?method : String
+}
+
+extern class Route {
+	@:overload(function() : Route {})
+	@:overload(function(headers : {}) : Route {})	
+	@:overload(function(path : String) : Route {})
+	public function route(path : String, headers : {}) : Route;
+	
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(qs : {}, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function get<T>(path : String, qs : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void;
+	
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, body : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function post<T>(path : String, body : Either<String, {}>, qs : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void;
+
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, body : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function put<T>(path : String, body : Either<String, {}>, qs : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void;	
+	
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, body : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function patch<T>(path : String, body : Either<String, {}>, qs : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void;	
+
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(qs : {}, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function delete<T>(path : String, qs : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void;
+
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(qs : {}, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	@:overload(function<T>(path : String, cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function head<T>(path : String, qs : Either<String, {}>, cb : ArangoCallback<RouteResponse<T>>) : Void;
+	
+	@:overload(function<T>(cb : ArangoCallback<RouteResponse<T>>) : Void {})
+	public function request<T>(opts : RouteRequestOptions, cb : ArangoCallback<RouteResponse<T>>) : Void;
+}

--- a/js/npm/arangojs/RouteResponse.hx
+++ b/js/npm/arangojs/RouteResponse.hx
@@ -1,0 +1,8 @@
+package js.npm.arangojs;
+
+import js.node.http.IncomingMessage;
+
+extern class RouteResponse<T> extends IncomingMessage {
+	public var body : T;
+	public var rawBody : String;
+}


### PR DESCRIPTION
Most of the callbacks are returning json data, and I realized `{}` isn't very suitable for a return value in those cases. `Dynamic` works better, until I have the energy to create proper typedefs for them all.