### PR TITLE
[mongoose] allow runinng custom code on a schema

### DIFF
--- a/util/Mongoose.hx
+++ b/util/Mongoose.hx
@@ -175,23 +175,26 @@ class Mongoose {
                 }
             }
         }
-        
         var typeKey = "type";
+        var post = macro null;
         switch(schemaOptions.expr) {
             case EObjectDecl(fields): 
-                var typeKeyField = Lambda.find(fields, function(f) return f.field == 'typeKey');
-                if(typeKeyField == null) {
-                    fields.push({field: 'typeKey', expr: macro $v{typeKey}});
-                } else {
-                    typeKey = switch(typeKeyField.expr.expr) {
-                        case EConst(CString(s)): s;
+                switch Lambda.find(fields, function(f) return f.field == 'typeKey') {
+                    case null: fields.push({field: 'typeKey', expr: macro $v{typeKey}});
+                    case v: switch v.expr.expr {
+                        case EConst(CString(s)): typeKey = s;
                         default: throw "typeKey should be string literal";
                     }
+                }
+                switch Lambda.find(fields, function(f) return f.field == 'post') {
+                    case null: // do nothing
+                    case v: 
+                        post = v.expr;
+                        fields.remove(v);
                 }
                     
             default:
         }
-        
 
 		switch(modelDecl){
 			case TAnonymous( a ):
@@ -249,6 +252,7 @@ class Mongoose {
 										case _ :
 									}
 								}
+								$post;
 							}
 							return _schema;
 


### PR DESCRIPTION
Allow running some code after a schema is initialized. Example:

```haxe
@:schemaOptions({
	autoIndex: true,
	typeKey: '__type__',
	post: {
		_schema.index({'email.address': 1}, {unique: true});
	}
})
```